### PR TITLE
Use plan.iterationmax instead of fixed limit

### DIFF
--- a/freppledb/execute/commands.py
+++ b/freppledb/execute/commands.py
@@ -121,7 +121,7 @@ class SupplyPlanning(PlanTask):
       minimumdelay=int(Parameter.getValue('plan.minimumdelay', database, '0')),
       rotateresources=(Parameter.getValue('plan.rotateResources', database, 'true').lower() == "true"),
       plansafetystockfirst=(Parameter.getValue('plan.planSafetyStockFirst', database, 'false').lower() != "false"),
-      iterationmax=int(Parameter.getValue('plan.iterationmax', database, '0')),
+      iterationmax=int(Parameter.getValue('plan.iterationmax', database, '500')),
       administrativeleadtime=86400 * float(Parameter.getValue('plan.administrativeLeadtime', database, '0')),
       autofence=86400 * float(Parameter.getValue("plan.autoFenceOperations", database, '0'))
       )

--- a/src/solver/solverresource.cpp
+++ b/src/solver/solverresource.cpp
@@ -330,10 +330,11 @@ void SolverCreate::solve(const Resource* res, void* v)
       }
       ++iterations;
     }
-    while (HasOverload && newDate && iterations < MAX_LOOP);
-    if (iterations >= MAX_LOOP)
-      logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
-        << " after " << MAX_LOOP << " iterations" << endl;
+    while (HasOverload && newDate && iterations < getIterationMax());
+	if (iterations >= getIterationMax()) {
+		logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
+			<< " after " << getIterationMax() << " iterations. Last date: " << newDate <<  endl;
+	}
     data->state->q_loadplan = old_q_loadplan;
 
     // Set the date where a next trial date can happen


### PR DESCRIPTION
When searching for LATER resource solver stops after MAX_LOOP iterations. Changed to make use of the existing parameter plan.iterationmax, so we can change number of iterations based on the needs.

Additionally, logging last checked resource availability date is useful for determining the correct value.