### PR TITLE
Add parameter to set LATER resource capacity search limit

### DIFF
--- a/freppledb/execute/commands.py
+++ b/freppledb/execute/commands.py
@@ -122,6 +122,7 @@ class SupplyPlanning(PlanTask):
       rotateresources=(Parameter.getValue('plan.rotateResources', database, 'true').lower() == "true"),
       plansafetystockfirst=(Parameter.getValue('plan.planSafetyStockFirst', database, 'false').lower() != "false"),
       iterationmax=int(Parameter.getValue('plan.iterationmax', database, '0')),
+      resourceiterationmax=int(Parameter.getValue('plan.resourceiterationmax', database, '500')),
       administrativeleadtime=86400 * float(Parameter.getValue('plan.administrativeLeadtime', database, '0')),
       autofence=86400 * float(Parameter.getValue("plan.autoFenceOperations", database, '0'))
       )

--- a/include/frepple/solver.h
+++ b/include/frepple/solver.h
@@ -579,6 +579,24 @@ class SolverCreate : public Solver
       iteration_max = d;
     }
 
+	/** Return the maximum number of tries allowed to look for LATER
+	* resource capacity. If can't find a capacity within this limit, we
+	* consider it unplannable.
+	*/
+	unsigned long getResourceIterationMax() const
+	{
+		return resource_iteration_max;
+	}
+
+	/** Update the maximum number of tries allowed to look for LATER
+	* resource capacity. If can't find a capacity within this limit, we
+	* consider it unplannable.
+	*/
+	void setResourceIterationMax(unsigned long d)
+	{
+		resource_iteration_max = d;
+	}
+
     /** Specify a Python function that is called before solving a flow. */
     void setUserExitFlow(PythonFunction n)
     {
@@ -733,6 +751,7 @@ class SolverCreate : public Solver
       m->addBoolField<Cls>(SolverCreate::tag_rotateresources, &Cls::getRotateResources, &Cls::setRotateResources);
       m->addBoolField<Cls>(SolverCreate::tag_planSafetyStockFirst, &Cls::getPlanSafetyStockFirst, &Cls::setPlanSafetyStockFirst);
       m->addUnsignedLongField<Cls>(SolverCreate::tag_iterationmax, &Cls::getIterationMax, &Cls::setIterationMax);
+	  m->addUnsignedLongField<Cls>(SolverCreate::tag_resourceiterationmax, &Cls::getResourceIterationMax, &Cls::setResourceIterationMax);
       m->addIntField<Cls>(Tags::cluster, &Cls::getCluster, &Cls::setCluster);
     }
 
@@ -751,6 +770,7 @@ class SolverCreate : public Solver
     static const Keyword tag_planSafetyStockFirst;
     static const Keyword tag_administrativeleadtime;
     static const Keyword tag_iterationmax;
+	static const Keyword tag_resourceiterationmax;
 
     /** Type of plan to be created. */
     short plantype = 1;
@@ -796,6 +816,12 @@ class SolverCreate : public Solver
       * unplannable.
       */
     unsigned long iteration_max = 0;
+
+	/** Maximum number of tries allowed to look for LATER
+	* resource capacity. If can't find a capacity within this limit, we
+	* consider it unplannable.
+	*/
+	unsigned long resource_iteration_max = 0;
 
     /** A Python callback function that is called for each alternate
       * flow. If the callback function returns false, that alternate

--- a/include/frepple/solver.h
+++ b/include/frepple/solver.h
@@ -579,23 +579,23 @@ class SolverCreate : public Solver
       iteration_max = d;
     }
 
-	/** Return the maximum number of tries allowed to look for LATER
-	* resource capacity. If can't find a capacity within this limit, we
-	* consider it unplannable.
-	*/
-	unsigned long getResourceIterationMax() const
-	{
-		return resource_iteration_max;
-	}
+    /** Return the maximum number of tries allowed to look for LATER
+    * resource capacity. If can't find a capacity within this limit, we
+    * consider it unplannable.
+    */
+    unsigned long getResourceIterationMax() const
+    {
+      return resource_iteration_max;
+    }
 
-	/** Update the maximum number of tries allowed to look for LATER
-	* resource capacity. If can't find a capacity within this limit, we
-	* consider it unplannable.
-	*/
-	void setResourceIterationMax(unsigned long d)
-	{
-		resource_iteration_max = d;
-	}
+    /** Update the maximum number of tries allowed to look for LATER
+    * resource capacity. If can't find a capacity within this limit, we
+    * consider it unplannable.
+    */
+    void setResourceIterationMax(unsigned long d)
+    {
+      resource_iteration_max = d;
+    }
 
     /** Specify a Python function that is called before solving a flow. */
     void setUserExitFlow(PythonFunction n)
@@ -751,7 +751,7 @@ class SolverCreate : public Solver
       m->addBoolField<Cls>(SolverCreate::tag_rotateresources, &Cls::getRotateResources, &Cls::setRotateResources);
       m->addBoolField<Cls>(SolverCreate::tag_planSafetyStockFirst, &Cls::getPlanSafetyStockFirst, &Cls::setPlanSafetyStockFirst);
       m->addUnsignedLongField<Cls>(SolverCreate::tag_iterationmax, &Cls::getIterationMax, &Cls::setIterationMax);
-	  m->addUnsignedLongField<Cls>(SolverCreate::tag_resourceiterationmax, &Cls::getResourceIterationMax, &Cls::setResourceIterationMax);
+      m->addUnsignedLongField<Cls>(SolverCreate::tag_resourceiterationmax, &Cls::getResourceIterationMax, &Cls::setResourceIterationMax);
       m->addIntField<Cls>(Tags::cluster, &Cls::getCluster, &Cls::setCluster);
     }
 
@@ -770,7 +770,7 @@ class SolverCreate : public Solver
     static const Keyword tag_planSafetyStockFirst;
     static const Keyword tag_administrativeleadtime;
     static const Keyword tag_iterationmax;
-	static const Keyword tag_resourceiterationmax;
+    static const Keyword tag_resourceiterationmax;
 
     /** Type of plan to be created. */
     short plantype = 1;
@@ -817,11 +817,11 @@ class SolverCreate : public Solver
       */
     unsigned long iteration_max = 0;
 
-	/** Maximum number of tries allowed to look for LATER
-	* resource capacity. If can't find a capacity within this limit, we
-	* consider it unplannable.
-	*/
-	unsigned long resource_iteration_max = 0;
+    /** Maximum number of tries allowed to look for LATER
+    * resource capacity. If can't find a capacity within this limit, we
+    * consider it unplannable.
+    */
+    unsigned long resource_iteration_max = 0;
 
     /** A Python callback function that is called for each alternate
       * flow. If the callback function returns false, that alternate

--- a/src/solver/solverplan.cpp
+++ b/src/solver/solverplan.cpp
@@ -34,6 +34,7 @@ const Keyword SolverCreate::tag_autofence("autofence");
 const Keyword SolverCreate::tag_rotateresources("rotateresources");
 const Keyword SolverCreate::tag_planSafetyStockFirst("plansafetystockfirst");
 const Keyword SolverCreate::tag_iterationmax("iterationmax");
+const Keyword SolverCreate::tag_resourceiterationmax("resourceiterationmax");
 
 
 void LibrarySolver::initialize()

--- a/src/solver/solverresource.cpp
+++ b/src/solver/solverresource.cpp
@@ -331,10 +331,10 @@ void SolverCreate::solve(const Resource* res, void* v)
       ++iterations;
     }
     while (HasOverload && newDate && iterations < getResourceIterationMax());
-	if (iterations >= getResourceIterationMax()) {
-		logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
-			<< " after " << getResourceIterationMax() << " iterations. Last date: " << newDate <<  endl;
-	}
+    if (iterations >= getResourceIterationMax()) {
+      logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
+        << " after " << getResourceIterationMax() << " iterations. Last date: " << newDate <<  endl;
+    }
     data->state->q_loadplan = old_q_loadplan;
 
     // Set the date where a next trial date can happen

--- a/src/solver/solverresource.cpp
+++ b/src/solver/solverresource.cpp
@@ -330,10 +330,11 @@ void SolverCreate::solve(const Resource* res, void* v)
       }
       ++iterations;
     }
-    while (HasOverload && newDate && iterations < MAX_LOOP);
-    if (iterations >= MAX_LOOP)
-      logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
-        << " after " << MAX_LOOP << " iterations" << endl;
+    while (HasOverload && newDate && iterations < getResourceIterationMax());
+	if (iterations >= getResourceIterationMax()) {
+		logger << indent(res->getLevel()) << "   Warning: no free capacity slot found on " << res
+			<< " after " << getResourceIterationMax() << " iterations. Last date: " << newDate <<  endl;
+	}
     data->state->q_loadplan = old_q_loadplan;
 
     // Set the date where a next trial date can happen


### PR DESCRIPTION
When searching for LATER resource solver stops after MAX_LOOP iterations. Changed to make use of the existing parameter plan.iterationmax, so we can change number of iterations based on the needs.

Additionally, logging last checked resource availability date is useful for determining the correct value.

The rationale behind this are situations when we know that right now there's no capacity to produce some new order. We want to be able to decide if it will be faster to increase the capacity of some resource (which in case of a additional machine can take even a few months) or just to plan further in the future with current resources. With adjustable limit we can execute such simulation for delays longer than 2-3 weeks.