### PR TITLE
fix for "NameError: name 'source' is not defined" error

### DIFF
--- a/freppledb/input/commands/export.py
+++ b/freppledb/input/commands/export.py
@@ -550,6 +550,7 @@ class exportSetupMatrices(PlanTask):
     def run(cls, database=DEFAULT_DB_ALIAS, **kwargs):
         import frepple
 
+        source = kwargs.get("source", None)
         attrs = [f[0] for f in getAttributes(SetupMatrix)]
 
         def getData():


### PR DESCRIPTION
This happened after executing task "odoo_import" on version 6.4.0. 
I think that you just forgot to define the "source" variable, so I defined it the same way it's done in other classes in this file. 

Original error:
```
ERROR Exception caught on thread exportstatic2
Error during planning: name 'source' is not defined
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 547, in <module>
    register.run(database=database)
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 487, in run
    cls.reg.run(**cls.arguments)
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 220, in run
    step.run(**PlanTaskRegistry.getArguments())
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 334, in run
    raise t.exception
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 297, in run
    self.seq.run(**self.kwargs)
  File "/usr/lib/python3/dist-packages/freppledb/common/commands.py", line 220, in run
    step.run(**PlanTaskRegistry.getArguments())
  File "/usr/lib/python3/dist-packages/freppledb/input/commands/export.py", line 573, in run
    getData(),
  File "/usr/lib/python3/dist-packages/psycopg2/extras.py", line 1198, in execute_batch
    for page in _paginate(argslist, page_size=page_size):
  File "/usr/lib/python3/dist-packages/psycopg2/extras.py", line 1169, in _paginate
    page.append(next(it))
  File "/usr/lib/python3/dist-packages/freppledb/input/commands/export.py", line 553, in getData
    if source and source != i.source:
NameError: name 'source' is not defined
Error: Error executing Python command
```