### PR TITLE
fixed odoo (v12,v13) action registry subclass

### DIFF
--- a/contrib/odoo/addons_v12/frepple/static/src/js/frepple.js
+++ b/contrib/odoo/addons_v12/frepple/static/src/js/frepple.js
@@ -2,14 +2,13 @@ odoo.define('frepple', function (require) {
   'use strict';
 
   var core = require('web.core');
-  var Widget = require('web.Widget');
+  var AbstractAction = require('web.AbstractAction');
 
-  /* Forecast editor widget. */
-  var ForecastEditor = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },
+  /* Forecast editor page. */
+  var ForecastEditor = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -26,12 +25,11 @@ odoo.define('frepple', function (require) {
   });
   core.action_registry.add('frepple.forecasteditor', ForecastEditor);
 
-  /* Inventory planning widget. */
-  var InventoryPlanning = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },  	
+  /* Inventory planning page. */
+  var InventoryPlanning = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -48,12 +46,11 @@ odoo.define('frepple', function (require) {
   });
   core.action_registry.add('frepple.inventoryplanning', InventoryPlanning);
 
-  /* Plan editor widget. */
-  var PlanEditor = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },  	
+  /* Plan editor page. */
+  var PlanEditor = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -70,19 +67,18 @@ odoo.define('frepple', function (require) {
   });
   core.action_registry.add('frepple.planeditor', PlanEditor);
 
-  /* Full user interface widget. */
-  var HomePage = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },
+  /* Full user interface page. */
+  var HomePage = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
         model: 'res.company',
         method: 'getFreppleURL',
         args: [true, '/'],
-        })      
+        })
         .then(function(result) {
           el.append('<iframe src="' + result
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
@@ -92,4 +88,10 @@ odoo.define('frepple', function (require) {
   });
   core.action_registry.add('frepple.homepage', HomePage);
 
+  return {
+    'frepple.forecasteditor': ForecastEditor,
+    'frepple.inventoryplanning': InventoryPlanning,
+    'frepple.planeditor': PlanEditor,
+    'frepple.homepage': HomePage,
+  };
 });

--- a/contrib/odoo/addons_v13/frepple/static/src/js/frepple.js
+++ b/contrib/odoo/addons_v13/frepple/static/src/js/frepple.js
@@ -21,6 +21,9 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
+    },
+    getTitle: function () {
+        return "Forecast Editor";
     }
   });
   core.action_registry.add('frepple.forecasteditor', ForecastEditor);
@@ -42,6 +45,9 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
+    },
+    getTitle: function () {
+        return "Inventory Planning";
     }
   });
   core.action_registry.add('frepple.inventoryplanning', InventoryPlanning);
@@ -63,6 +69,9 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
+    },
+    getTitle: function () {
+        return "Plan Editor";
     }
   });
   core.action_registry.add('frepple.planeditor', PlanEditor);
@@ -84,6 +93,9 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
+    },
+    getTitle: function () {
+        return "frePPLe";
     }
   });
   core.action_registry.add('frepple.homepage', HomePage);

--- a/contrib/odoo/addons_v13/frepple/static/src/js/frepple.js
+++ b/contrib/odoo/addons_v13/frepple/static/src/js/frepple.js
@@ -2,14 +2,13 @@ odoo.define('frepple', function (require) {
   'use strict';
 
   var core = require('web.core');
-  var Widget = require('web.Widget');
+  var AbstractAction = require('web.AbstractAction');
 
-  /* Forecast editor widget. */
-  var ForecastEditor = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },
+  /* Forecast editor page. */
+  var ForecastEditor = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -22,19 +21,15 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
-    },
-    getTitle: function () {
-        return "Forecast Editor";
     }
   });
   core.action_registry.add('frepple.forecasteditor', ForecastEditor);
 
-  /* Inventory planning widget. */
-  var InventoryPlanning = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },  	
+  /* Inventory planning page. */
+  var InventoryPlanning = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -47,19 +42,15 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
-    },
-    getTitle: function () {
-        return "Inventory Planning";
     }
   });
   core.action_registry.add('frepple.inventoryplanning', InventoryPlanning);
 
-  /* Plan editor widget. */
-  var PlanEditor = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },  	
+  /* Plan editor page. */
+  var PlanEditor = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
@@ -72,36 +63,35 @@ odoo.define('frepple', function (require) {
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
-    },
-    getTitle: function () {
-        return "Plan Editor";
     }
   });
   core.action_registry.add('frepple.planeditor', PlanEditor);
 
-  /* Full user interface widget. */
-  var HomePage = Widget.extend({
-    canBeRemoved: function () {
-      return $.when();
-      },
+  /* Full user interface page. */
+  var HomePage = AbstractAction.extend({
     start: function() {
+      this._super.apply(this, arguments);
+
       var el = this.$el;
       el.height("calc(100% - 34px)");
       this._rpc({
         model: 'res.company',
         method: 'getFreppleURL',
         args: [true, '/'],
-        })      
+        })
         .then(function(result) {
           el.append('<iframe src="' + result
             + '" width="100%" height="100%" marginwidth="0" marginheight="0" frameborder="no" '
             + ' scrolling="yes" style="border-width:0px;"/>');
           });
-    },
-    getTitle: function () {
-        return "frePPLe";
     }
   });
   core.action_registry.add('frepple.homepage', HomePage);
 
+  return {
+    'frepple.forecasteditor': ForecastEditor,
+    'frepple.inventoryplanning': InventoryPlanning,
+    'frepple.planeditor': PlanEditor,
+    'frepple.homepage': HomePage,
+  };
 });


### PR DESCRIPTION
Since Odoo v12, values in action registry must be subclass of AbstractAction.
https://www.odoo.com/documentation/12.0/reference/javascript_reference.html#registries

Current version caused following Javascript error:
```
Uncaught TypeError: currentController.widget.on_attach_callback is not a function
http://localhost/web/static/src/js/chrome/action_manager.js:84
Traceback:
TypeError: currentController.widget.on_attach_callback is not a function
    at Class.on_attach_callback (http://localhost/web/static/src/js/chrome/action_manager.js:84:38)
    at http://localhost/web/static/src/js/core/dom.js:38:22
    at Function._.each._.forEach (http://localhost/web/static/lib/underscore/underscore.js:145:9)
    at _notify (http://localhost/web/static/src/js/core/dom.js:36:7)
    at Object.append (http://localhost/web/static/src/js/core/dom.js:60:13)
    at Class.toggle_home_menu (http://localhost/web_enterprise/static/src/js/web_client.js:305:17)
    at http://localhost/web_enterprise/static/src/js/web_client.js:193:30
    at http://localhost/web/static/lib/jquery/jquery.js:3276:89
    at fire (http://localhost/web/static/lib/jquery/jquery.js:3119:58)
    at Object.fireWith [as resolveWith] (http://localhost/web/static/lib/jquery/jquery.js:3231:49)
```