### PR TITLE
fixed odoo (v8-v13) exported operation duration value

### DIFF
--- a/contrib/odoo/addons_v10/frepple/controllers/outbound.py
+++ b/contrib/odoo/addons_v10/frepple/controllers/outbound.py
@@ -181,6 +181,16 @@ class exporter(object):
             return qty
         return qty * self.uom[uom_id]["factor"]
 
+    def convert_float_time(self, float_time):
+        """
+        Convert Odoo float time to ISO 8601 duration.
+        """
+        return "PT%dH%dM%dS" % (
+            int(float_time),  # duration: hours
+            int((float_time*60) % 60),  # duration: minutes
+            int((float_time*3600) % 60 % 60),  # duration: seconds
+        )
+
     def export_calendar(self):
         """
         Build a calendar with a) holidays and b) working hours.
@@ -629,9 +639,9 @@ class exporter(object):
                 # CASE 1: A single operation used for the BOM
                 # All routing steps are collapsed in a single operation.
                 #
-                yield '<operation name=%s size_multiple="1" duration="PT%dH" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
+                yield '<operation name=%s size_multiple="1" duration="%s" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
                     quoteattr(operation),
-                    int(
+                    self.convert_float_time(
                         self.product_templates[i["product_tmpl_id"][0]]["produce_delay"]
                     ),
                     self.manufacturing_lead,
@@ -720,10 +730,10 @@ class exporter(object):
                 yield "<suboperations>"
                 steplist = mrp_routing_workcenters[i["routing_id"][0]]
                 for step in steplist:
-                    yield '<suboperation priority="%s">' '<operation name=%s duration="PT%dH" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
+                    yield '<suboperation priority="%s">' '<operation name=%s duration="%s" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
                         step[2],
                         quoteattr("%s - %s" % (operation, step[2])),
-                        int(step[1]),
+                        self.convert_float_time(step[1]),
                         quoteattr(location),
                         step[1],
                         quoteattr(step[0]),

--- a/contrib/odoo/addons_v12/frepple/controllers/outbound.py
+++ b/contrib/odoo/addons_v12/frepple/controllers/outbound.py
@@ -180,6 +180,16 @@ class exporter(object):
             return qty
         return qty * self.uom[uom_id]["factor"]
 
+    def convert_float_time(self, float_time):
+        """
+        Convert Odoo float time to ISO 8601 duration.
+        """
+        return "PT%dH%dM%dS" % (
+            int(float_time),  # duration: hours
+            int((float_time*60) % 60),  # duration: minutes
+            int((float_time*3600) % 60 % 60),  # duration: seconds
+        )
+
     def export_calendar(self):
         """
         Build a calendar with a) holidays and b) working hours.
@@ -675,9 +685,9 @@ class exporter(object):
                 # CASE 1: A single operation used for the BOM
                 # All routing steps are collapsed in a single operation.
                 #
-                yield '<operation name=%s size_multiple="1" duration="PT%dH" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
+                yield '<operation name=%s size_multiple="1" duration="%s" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
                     quoteattr(operation),
-                    int(
+                    self.convert_float_time(
                         self.product_templates[i["product_tmpl_id"][0]]["produce_delay"]
                     ),
                     self.manufacturing_lead,
@@ -766,12 +776,12 @@ class exporter(object):
                 for step in steplist:
                     counter = counter + 1
                     suboperation = step[3]
-                    yield "<suboperation>" '<operation name=%s priority="%s" duration="PT%dH" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
+                    yield "<suboperation>" '<operation name=%s priority="%s" duration="%s" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
                         quoteattr(
                             "%s - %s - %s" % (operation, suboperation, (counter * 100))
                         ),
                         counter * 10,
-                        int(step[1]),
+                        self.convert_float_time(step[1]),
                         quoteattr(location),
                         1,
                         quoteattr(step[0]),

--- a/contrib/odoo/addons_v13/frepple/controllers/outbound.py
+++ b/contrib/odoo/addons_v13/frepple/controllers/outbound.py
@@ -180,6 +180,16 @@ class exporter(object):
             return qty
         return qty * self.uom[uom_id]["factor"]
 
+    def convert_float_time(self, float_time):
+        """
+        Convert Odoo float time to ISO 8601 duration.
+        """
+        return "PT%dH%dM%dS" % (
+            int(float_time),  # duration: hours
+            int((float_time*60) % 60),  # duration: minutes
+            int((float_time*3600) % 60 % 60),  # duration: seconds
+        )
+
     def export_calendar(self):
         """
         Build a calendar with a) holidays and b) working hours.
@@ -636,9 +646,9 @@ class exporter(object):
                 # CASE 1: A single operation used for the BOM
                 # All routing steps are collapsed in a single operation.
                 #
-                yield '<operation name=%s size_multiple="1" duration="PT%dH" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
+                yield '<operation name=%s size_multiple="1" duration="%s" posttime="P%dD" xsi:type="operation_fixed_time">\n' "<item name=%s/><location name=%s/>\n" % (
                     quoteattr(operation),
-                    int(
+                    self.convert_float_time(
                         self.product_templates[i["product_tmpl_id"][0]]["produce_delay"]
                     ),
                     self.manufacturing_lead,
@@ -727,12 +737,12 @@ class exporter(object):
                 for step in steplist:
                     counter = counter + 1
                     suboperation = step[3]
-                    yield "<suboperation>" '<operation name=%s priority="%s" duration="PT%dH" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
+                    yield "<suboperation>" '<operation name=%s priority="%s" duration="%s" xsi:type="operation_fixed_time">\n' "<location name=%s/>\n" '<loads><load quantity="%f"><resource name=%s/></load></loads>\n' % (
                         quoteattr(
                             "%s - %s - %s" % (operation, suboperation, (counter * 100))
                         ),
                         counter * 10,
-                        int(step[1]),
+                        self.convert_float_time(step[1]),
                         quoteattr(location),
                         1,
                         quoteattr(step[0]),

--- a/contrib/odoo/addons_v8/frepple/controllers/outbound.py
+++ b/contrib/odoo/addons_v8/frepple/controllers/outbound.py
@@ -172,6 +172,17 @@ converts to the reference unit of the uom category.
         return qty * self.uom[uom_id]['factor']
 
 
+    def convert_float_time(self, float_time):
+        """
+        Convert Odoo float time to ISO 8601 duration.
+        """
+        return "PT%dH%dM%dS" % (
+            int(float_time),  # duration: hours
+            int((float_time*60) % 60),  # duration: minutes
+            int((float_time*3600) % 60 % 60),  # duration: seconds
+        )
+
+
     def export_calendar(self):
         '''
 Build a calendar with a) holidays and b) working hours.
@@ -568,9 +579,9 @@ Mapping:
             yield '<buffer name=%s><item name=%s/><location name=%s/>\n' % (
                 quoteattr(buf_name), quoteattr(product_buf['name']), quoteattr(location)
             )
-            yield '<producing name=%s size_multiple="%s" duration="PT%dH" posttime="P%dD" xsi:type="operation_fixed_time"><location name=%s/>\n' % (
+            yield '<producing name=%s size_multiple="%s" duration="%s" posttime="P%dD" xsi:type="operation_fixed_time"><location name=%s/>\n' % (
                 quoteattr(operation), (i['product_rounding'] * uom_factor) or 1,
-                int(self.product_templates[self.product_product[i['product_tmpl_id'][0]]['template']]['produce_delay']),
+                self.convert_float_time(self.product_templates[self.product_product[i['product_tmpl_id'][0]]['template']]['produce_delay']),
                 self.manufacturing_lead,
                 quoteattr(location)
             )


### PR DESCRIPTION
Odoo connector did not correctly export durations of workcenter operations (mrp.routing.workcenter). Only hours were exported. 

For example: Odoo workcenter operation with duration 2:30 created frePPLe operation with duration 2:00.