### PR TITLE
fix jsonb parse after get value from database

### DIFF
--- a/freppledb/common/fields.py
+++ b/freppledb/common/fields.py
@@ -49,8 +49,25 @@ class JSONField(models.TextField):
 
     def to_python(self, value):
         """Convert a json string to a Python value."""
+        if value is None:
+            return value
         if isinstance(value, str) and value:
-            return json.loads(value)
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+        else:
+            return value
+
+    def from_db_value(self, value, expression, connection):
+        """Convert a json string to a Python value."""
+        if value is None:
+            return value
+        if isinstance(value, str) and value:
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
         else:
             return value
 


### PR DESCRIPTION
In my development environment, the `UserPreference` will always return `value` as str although it is set to JSONBField.
![image](https://user-images.githubusercontent.com/1894696/121771286-0e003580-cba1-11eb-854f-86269e08a223.png)

I dig deeper and found the model of django needs `from_db_value` to do the type convert job.
![image](https://user-images.githubusercontent.com/1894696/121771310-2a9c6d80-cba1-11eb-8c91-fffecdacbe3e.png)

So added this function for JSONField to support auto convert. Please kindly review this. Thanks!

VERSIONS:
Python == 3.7.10
django == 3.2.4
djangorestframework == 3.12.4
djangorestframework-bulk == 0.2
djangorestframework-filters == 1.0.0.dev2
django-admin-bootstrapped == 2.5.6
django-bootstrap3 == 11.1.0
django-filter == 2.4.0