### PR TITLE
fix: docker add SECURE_PROXY_SSL_HEADER env config

### DIFF
--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -25,6 +25,11 @@ if [ -n "$POSTGRES_DBNAME" ]; then
   sed -i "s/\"NAME\": \"test_scenario\(.*\)\"/\"NAME\": \"test_${POSTGRES_DBNAME}\1\"/g" /etc/frepple/djangosettings.py
 fi
 
+# Needend when running behind nginx and the error CSRF verification failed appears https://stackoverflow.com/questions/70501974/django-returning-csrf-verification-failed-request-aborted-behind-nginx-prox
+if [ -n "$"SECURE_PROXY_SSL_HEADER ]; then
+  sed -i 's/# SECURE_PROXY_SSL_HEADER/SECURE_PROXY_SSL_HEADER/g' /etc/frepple/djangosettings.py
+fi
+
 # Djangosettings must be writeable by the web server to support installing&uninstalling apps
 chmod g+w /etc/frepple/djangosettings.py
 


### PR DESCRIPTION
Found that when running in Kubernetes behind an nginx proxy that adds https then was seeing the following error in the logs:

```
[Fri May 17 13:51:18.518462 2024] [wsgi:error] [pid 28:tid 136755443365632] [remote 10.20.2.3:39312] ERROR CSRF failure detected
[Fri May 17 13:51:18.518699 2024] [wsgi:error] [pid 28:tid 136755443365632] [remote 10.20.2.3:39312] INFO Forbidden (Origin checking failed - https://frepple.kencove.com/ does not match any trusted origins.): /data/login/
```

See also:
https://stackoverflow.com/questions/70501974/django-returning-csrf-verification-failed-request-aborted-behind-nginx-prox

As a fix added a variable _SECURE_PROXY_SSL_HEADER_ when set it will un-comment that line in the config file.