### PR TITLE
Fix getStorageUsage() total_size value, when there are no Scenario objects in database

### DIFF
--- a/freppledb/common/utils.py
+++ b/freppledb/common/utils.py
@@ -56,5 +56,7 @@ def getStorageUsage():
         cursor.execute(
             "select %s" % " + ".join(["pg_database_size(%s)"] * len(dblist)), dblist
         )
-        total_size += cursor.fetchone()[0]
+        dbsizevalue = cursor.fetchone()
+        if len(dbsizevalue) > 0:
+            total_size += dbsizevalue[0]
     return total_size


### PR DESCRIPTION
When running frePPLe for the first time, clicking Help->About FrePPLe will throw Server Error 500:

![image](https://github.com/user-attachments/assets/87c743f9-c4a2-4c16-802c-de931aac820e)

Following error log in apache, we can see:

![image](https://github.com/user-attachments/assets/3afee573-7702-4c03-883f-b72b4987b409)

And that's, because there are no Scenario objects in database, and `fetchone()` returns `()` tuple, which we cannot select first element from.

My fix only add's size value from `fetchone()`, if there is anything to add. Tested on latest master branch build:

![image](https://github.com/user-attachments/assets/faa5e715-f8de-463d-a286-b53dfd76cc67)
