### PR TITLE
Clean up "scratch" image in Dockerfile definitions

### DIFF
--- a/contrib/docker/ubuntu-24.04.dockerfile
+++ b/contrib/docker/ubuntu-24.04.dockerfile
@@ -48,9 +48,6 @@ RUN src=`basename --suffix=.tar.gz frepple-*` && \
   cmake -B /build -DCMAKE_BUILD_TYPE=Release && \
   cmake --build /build --config Release --target package -- -j 2
 
-FROM scratch as package
-COPY --from=builder /build/*.deb .
-
 #
 # STAGE 2: Build the deployment container
 #

--- a/contrib/docker/ubuntu-devel.dockerfile
+++ b/contrib/docker/ubuntu-devel.dockerfile
@@ -48,9 +48,6 @@ RUN src=`basename --suffix=.tar.gz frepple-*` && \
   cmake -B /build -DCMAKE_BUILD_TYPE=Release && \
   cmake --build /build --config Release --target package -- -j 2
 
-FROM scratch as package
-COPY --from=builder /build/*.deb .
-
 #
 # STAGE 2: Build the deployment container
 #


### PR DESCRIPTION
I don't see any reference to "scratch" image being used elsewhere. I was able to build docker images successfully without those image definitions, as they really aren't doing anything special.