### PR TITLE
Publish the docker image as a multi-arch (amd64 + arm64) manifest

### DIFF
--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -60,7 +60,6 @@ jobs:
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
           cmake --build ${{github.workspace}}/build --config Release --target package -- -j 4
           cmake --build ${{github.workspace}}/build --config Release --target doc
-          cp djangosettings.py djangosettings.original.py
           . ${{github.workspace}}/venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
@@ -114,23 +113,6 @@ jobs:
             exit 1
           fi
 
-      - name: Login to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'frePPLe/frepple'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push docker image
-        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'frePPLe/frepple'
-        run: |
-          mv djangosettings.original.py djangosettings.py
-          cmake --build ${{github.workspace}}/build --config Release --target docker
-          docker tag  ghcr.io/frepple/frepple-community:${{ env.frepple_version }} ghcr.io/frepple/frepple-community:latest
-          docker push ghcr.io/frepple/frepple-community:${{ env.frepple_version }}
-          docker push ghcr.io/frepple/frepple-community:latest
-
       - name: Publish release
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'frePPLe/frepple'
         uses: softprops/action-gh-release@v2
@@ -162,3 +144,93 @@ jobs:
             Please check the logs at https://github.com/frePPLe/frepple/actions/runs/${{ github.run_id }}
           html_body: |
             <p>Please check <a href="https://github.com/frePPLe/frepple/actions/runs/${{ github.run_id }}">the logs</a>.</p>
+
+  # Build the runtime image natively on each architecture and push it under an
+  # architecture-specific tag. A native arm64 runner avoids QEMU emulation,
+  # keeping the arm64 build as fast as the amd64 one. The `merge` job then
+  # stitches the two into a single multi-arch manifest.
+  #
+  # The image name is taken from the tag the build produces, so these jobs
+  # work unchanged for the enterprise edition once
+  # `frePPLe/frepple-enterprise-dev` is added to the `if:` guards below.
+  docker:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'frePPLe/frepple'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      image: ${{ steps.push.outputs.image }}
+    steps:
+      - name: Checking out source code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Nodes
+        uses: actions/setup-node@v6
+
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install --no-upgrade libxerces-c-dev openssl libssl-dev libpq5 libpq-dev postgresql-client python3 python3-dev python3-venv python3-setuptools
+          sudo npm -g install pnpm@latest-10
+          pnpm install --frozen-lockfile
+
+      - name: Build the docker image
+        run: |
+          git submodule update --remote --checkout --force
+          grunt
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+          cmake --build ${{github.workspace}}/build --config Release --target docker
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push architecture-specific image
+        id: push
+        run: |
+          version=${GITHUB_REF#refs/tags/}
+          arch=${{ matrix.platform }}
+          arch=${arch#linux/}
+          # Image name (frepple-community / frepple-enterprise) is taken from
+          # the tag the cmake `docker` target produced -- no edition hardcoded.
+          image=$(docker image ls --format '{{.Repository}}' | grep -m1 -E '/frepple-(community|enterprise)$')
+          docker tag "$image:$version" "$image:$version-$arch"
+          docker push "$image:$version-$arch"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+  # Stitch the per-architecture images into one multi-arch manifest list,
+  # published as the :<version> and :latest tags.
+  merge:
+    needs: [build, docker]
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'frePPLe/frepple'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push the multi-arch manifest
+        run: |
+          version=${GITHUB_REF#refs/tags/}
+          image=${{ needs.docker.outputs.image }}
+          docker buildx imagetools create \
+            --tag "$image:$version" \
+            --tag "$image:latest" \
+            "$image:$version-amd64" \
+            "$image:$version-arm64"
+          docker buildx imagetools inspect "$image:$version"


### PR DESCRIPTION
Closes #716.

The published `ghcr.io/frepple/frepple-community` image is currently linux/amd64 only. This publishes it as a multi-arch **amd64 + arm64** manifest, so frePPLe runs natively on arm64 hosts (AWS Graviton, Ampere, Apple Silicon) without QEMU emulation.

## Approach

The docker build and push move out of the `build` job into a dedicated `docker` job, built as a **native matrix** — amd64 on `ubuntu-24.04`, arm64 on `ubuntu-24.04-arm` — and a `merge` job stitches the two into one manifest list with `docker buildx imagetools`. Native runners avoid QEMU, so the arm64 leg compiles the C++ engine at native speed (~9 min, vs ~8 min for amd64).

- `build` still runs once on amd64 (test suite, release assets) — unchanged.
- The image name is read from the tag the cmake `docker` target produces, so the jobs are not edition-hardcoded.
- Both new jobs keep the existing `frePPLe/frepple` guard, so the enterprise build is untouched. To extend multi-arch to the EE image, add `frePPLe/frepple-enterprise-dev` to the two `if:` guards — nothing else changes. (`ubuntu-24.04-arm` runners are free for public repos but billed on private ones.)

## Validation

Dry-run on a fork with the guards and image namespace retargeted: https://github.com/macroscoop/frepple/actions/runs/26171366257 — all four jobs green. The resulting `:<version>` is a `manifest.list.v2` with `linux/amd64` + `linux/arm64` entries, and the compiled `frepple` binary inside each image is the correct native ELF.

Per-architecture images are pushed as `:<version>-<arch>` tags and then merged; those interim tags remain in the registry — happy to add a prune step or switch to push-by-digest if you prefer.
