### PR TITLE
fix: correct inverted lower-bound clamp in JSON getLong/getInt

### DIFF
--- a/src/utils/json.cpp
+++ b/src/utils/json.cpp
@@ -802,7 +802,7 @@ long JSONData::getLong() const {
     case JSON_DOUBLE:
       if (data_double > LONG_MAX)
         return LONG_MAX;
-      else if (data_double > LONG_MIN)
+      else if (data_double < LONG_MIN)
         return LONG_MIN;
       else
         return static_cast<long>(data_double);
@@ -877,7 +877,7 @@ int JSONData::getInt() const {
     case JSON_DOUBLE:
       if (data_double > INT_MAX)
         return INT_MAX;
-      else if (data_double > INT_MIN)
+      else if (data_double < INT_MIN)
         return INT_MIN;
       else
         return static_cast<int>(data_double);


### PR DESCRIPTION
`else if (data_double > LONG_MIN)` is true for nearly all values, so `JSONData::getLong()` returns `LONG_MIN` instead of the number. `getInt()` has the same `> INT_MIN` bug. The clamp should be `< LONG_MIN` / `< INT_MIN`.